### PR TITLE
Fix text overflow into sidebar on content pages

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -88,12 +88,23 @@ article h4 {
 // --- Content area: prevent text from overflowing into sidebars ---
 .center {
   min-width: 0;          // allow grid item to shrink below content size
+  max-width: 100%;
+  overflow: hidden;      // hard-clip anything that escapes the grid column
   overflow-wrap: break-word;
   word-break: break-word;
 }
 
 .center > article {
   min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+// Force long inline content (wikilinks, URLs) to wrap
+article p, article li, article td {
+  max-width: 100%;
   overflow-wrap: break-word;
   word-break: break-word;
 }


### PR DESCRIPTION
## Summary
- Add `overflow: hidden` and `max-width: 100%` to `.center` and `article` to hard-clip content escaping the grid column
- Add word-break rules to `p`, `li`, and `td` elements to force long inline content (wikilinks, URLs) to wrap

## Test plan
- [ ] Check contradiction deep dive pages — text should no longer bleed into right sidebar
- [ ] Verify normal pages still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)