### PR TITLE
Link content/ to Obsidian vault, ignore drafts

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -15,7 +15,7 @@ const config: QuartzConfig = {
     analytics: null,
     locale: "en-US",
     baseUrl: "guerillapropaganda.github.io/donor-map-site",
-    ignorePatterns: ["private", "templates", ".obsidian", "_templates", "Vault Maintenance", "Excalidraw", "Assets"],
+    ignorePatterns: ["private", "templates", ".obsidian", "_templates", "Vault Maintenance", "Excalidraw", "Assets", "DRAFT-*", "publish.css", "_VAULT_INDEX.md"],
     defaultDateType: "modified",
     theme: {
       fontOrigin: "googleFonts",


### PR DESCRIPTION
## Summary
- content/ is now a junction to `C:\Users\third\Documents\Obsidian Vaults\topics`
- Edits in Obsidian are immediately reflected in site source
- Added ignore patterns: `DRAFT-*`, `publish.css`, `_VAULT_INDEX.md`
- Copied `index.md`, `Methodology.md`, and `Interactive/` folder into vault (were missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)