### PR TITLE
Fix broken dollar amounts: disable LaTeX math rendering

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -69,7 +69,7 @@ const config: QuartzConfig = {
       Plugin.TableOfContents(),
       Plugin.CrawlLinks({ markdownLinkResolution: "shortest" }),
       Plugin.Description(),
-      Plugin.Latex({ renderEngine: "katex" }),
+      // Plugin.Latex({ renderEngine: "katex" }), // disabled — breaks $ currency amounts across the site
     ],
     filters: [],
     emitters: [


### PR DESCRIPTION
## Summary
- Disables the KaTeX/LaTeX plugin that was interpreting `$` currency signs as math delimiters
- Fixes text smashing together and missing dollar signs across all profile pages
- No LaTeX math content exists on this site — all `$` usage is for currency

## Test plan
- [ ] Check profile pages with dollar amounts — text renders normally with `$` signs visible
- [ ] Verify no other formatting regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)