### PR TITLE
Fix profile dashboard cards not appearing (case-sensitive slug)

### DIFF
--- a/quartz/components/ProfileHeader.tsx
+++ b/quartz/components/ProfileHeader.tsx
@@ -49,7 +49,7 @@ function wrapProfileSections() {
   if (article.dataset.sectionsWrapped === 'true') return;
 
   // Only run on master profile pages
-  var slug = document.body.dataset.slug || '';
+  var slug = (document.body.dataset.slug || '').toLowerCase();
   if (slug.indexOf('master-profile') === -1) return;
 
   var children = Array.from(article.children);

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1267,7 +1267,7 @@ body:has(.lp-landing) .breadcrumb-container {
 }
 
 // ── Section Cards (created by JS) ──
-body[data-slug*="master-profile"] {
+body[data-slug*="master-profile" i] {
 
   // Hide horizontal rules — cards provide separation
   article hr {
@@ -1465,7 +1465,7 @@ body[data-slug*="master-profile"] {
     padding: 10px 14px;
   }
 
-  body[data-slug*="master-profile"] {
+  body[data-slug*="master-profile" i] {
     .profile-section-card {
       padding: 18px 16px;
       border-radius: 6px;


### PR DESCRIPTION
## Summary
- Quartz slugs preserve original case: `Master-Profile` not `master-profile`
- CSS selector `body[data-slug*="master-profile"]` didn't match — added `i` flag for case-insensitive matching
- DOM script `indexOf('master-profile')` didn't match — added `.toLowerCase()`
- Profile cards, colored borders, and metadata badges should now render on all master profile pages

## Test plan
- [ ] Check Pelosi master profile — section cards with colored borders visible
- [ ] Contradiction sections have red left border
- [ ] Donor sections have green left border
- [ ] Metadata badges visible at top of profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)