### PR TITLE
Fix profile cards: target H3 headings used in profile markdown

### DIFF
--- a/quartz/components/ProfileHeader.tsx
+++ b/quartz/components/ProfileHeader.tsx
@@ -60,7 +60,7 @@ function wrapProfileSections() {
   for (var i = 0; i < children.length; i++) {
     var el = children[i];
 
-    if (el.tagName === 'H2') {
+    if (el.tagName === 'H2' || el.tagName === 'H3') {
       // Close previous card
       if (currentCard) {
         fragment.appendChild(currentCard);
@@ -137,6 +137,8 @@ function wrapProfileSections() {
 
 wrapProfileSections();
 document.addEventListener('nav', function() {
+  var art = document.querySelector('article');
+  if (art) art.dataset.sectionsWrapped = '';
   setTimeout(wrapProfileSections, 100);
 });
 `

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1287,8 +1287,8 @@ body[data-slug*="master-profile" i] {
       border-color: rgba(99, 102, 241, 0.2);
     }
 
-    // H2 inside card — card header
-    h2 {
+    // Heading inside card — card header
+    h2, h3 {
       margin-top: 0 !important;
       padding-bottom: 12px;
       margin-bottom: 16px;
@@ -1298,8 +1298,9 @@ body[data-slug*="master-profile" i] {
       scroll-margin-top: 24px;
     }
 
-    // Remove extra top margin from first element after h2
-    h2 + p, h2 + ul, h2 + ol, h2 + blockquote, h2 + table {
+    // Remove extra top margin from first element after heading
+    h2 + p, h2 + ul, h2 + ol, h2 + blockquote, h2 + table,
+    h3 + p, h3 + ul, h3 + ol, h3 + blockquote, h3 + table {
       margin-top: 0;
     }
 


### PR DESCRIPTION
## Summary
- Profile markdown uses `###` (H3) for section headings, not `##` (H2)
- Section-wrapping script now matches both H2 and H3
- CSS card header styles now apply to both h2 and h3 inside cards
- Fixed SPA nav: reset sectionsWrapped flag so cards render on page transitions

## Test plan
- [ ] Pelosi profile shows colored section cards
- [ ] Contradiction sections have red left border
- [ ] Table of Contents links still scroll to correct sections
- [ ] Navigating between profiles via SPA re-renders cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)