### PR TITLE
Style profile tags as pills, related/donors as reference blocks

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1274,6 +1274,56 @@ body[data-slug*="master-profile" i] {
     display: none !important;
   }
 
+  // ── Preamble: tags, related, donors ──
+  // Tag pills — first paragraph contains .tag-link elements
+  article > p:first-child {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 16px;
+    padding-bottom: 16px;
+    border-bottom: 1px solid #1e1e28;
+
+    .tag-link {
+      display: inline-block;
+      background: rgba(99, 102, 241, 0.12);
+      color: #818cf8;
+      border: 1px solid rgba(99, 102, 241, 0.25);
+      border-radius: 4px;
+      padding: 3px 10px;
+      font-size: 0.72rem;
+      font-family: "Space Mono", monospace;
+      letter-spacing: 0.03em;
+      text-transform: uppercase;
+      text-decoration: none;
+      transition: background 0.2s, border-color 0.2s;
+
+      &:hover {
+        background: rgba(99, 102, 241, 0.22);
+        border-color: #818cf8;
+      }
+    }
+  }
+
+  // Related/donors reference blocks
+  article > p:nth-child(2),
+  article > p:nth-child(3) {
+    background: #0e0e14;
+    border: 1px solid #1e1e28;
+    border-radius: 6px;
+    padding: 12px 16px;
+    margin-bottom: 12px;
+    font-size: 0.82rem;
+    line-height: 1.6;
+    color: #8b8b9e;
+
+    a {
+      color: #a5b4fc;
+      text-decoration: none;
+      &:hover { text-decoration: underline; }
+    }
+  }
+
   // Section card container
   .profile-section-card {
     background: #111118;


### PR DESCRIPTION
## Summary
- Tags rendered as compact purple pill badges (uppercase, monospace, hover effect)
- Related and donors paragraphs styled as muted reference blocks with borders
- Matches the overall dashboard card aesthetic

## Test plan
- [ ] Tags display as pill badges, not raw text
- [ ] Related/donors sections have subtle card background
- [ ] Links in related/donors are clickable and styled

🤖 Generated with [Claude Code](https://claude.com/claude-code)