### PR TITLE
Hide internal Obsidian dataview fields on profile pages

### DIFF
--- a/quartz/components/ProfileHeader.tsx
+++ b/quartz/components/ProfileHeader.tsx
@@ -135,11 +135,26 @@ function wrapProfileSections() {
   article.dataset.sectionsWrapped = 'true';
 }
 
+function hideDataviewFields() {
+  var article = document.querySelector('article');
+  if (!article) return;
+  var slug = (document.body.dataset.slug || '').toLowerCase();
+  if (slug.indexOf('master-profile') === -1) return;
+  var ps = article.querySelectorAll('p');
+  for (var i = 0; i < ps.length; i++) {
+    var t = ps[i].textContent || '';
+    if (t.match(/^[a-z-]+::\s/)) {
+      ps[i].style.display = 'none';
+    }
+  }
+}
+
 wrapProfileSections();
+hideDataviewFields();
 document.addEventListener('nav', function() {
   var art = document.querySelector('article');
   if (art) art.dataset.sectionsWrapped = '';
-  setTimeout(wrapProfileSections, 100);
+  setTimeout(function() { wrapProfileSections(); hideDataviewFields(); }, 100);
 });
 `
 


### PR DESCRIPTION
## Summary
- Hides paragraphs starting with `key:: value` pattern (Obsidian dataview inline fields)
- These are internal research metadata (profile-status, research-status, content-readiness)
- Not meant to be visible to readers

## Test plan
- [ ] "profile-status:: ready" text no longer visible on Pelosi profile
- [ ] Actual content paragraphs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)