### PR TITLE
Replace em dashes with semicolons site-wide

### DIFF
--- a/quartz/components/InteractiveGraphs.tsx
+++ b/quartz/components/InteractiveGraphs.tsx
@@ -671,9 +671,24 @@ function initInteractive() {
   if (bs) renderBothSides(bs);
 }
 
+// Replace em dashes with semicolons in article text
+function replaceEmDashes() {
+  var article = document.querySelector('article');
+  if (!article) return;
+  var em = String.fromCharCode(8212);
+  var walker = document.createTreeWalker(article, NodeFilter.SHOW_TEXT);
+  var node;
+  while (node = walker.nextNode()) {
+    if (node.nodeValue && node.nodeValue.indexOf(em) !== -1) {
+      node.nodeValue = node.nodeValue.split(em).join('; ');
+    }
+  }
+}
+
 initInteractive();
+replaceEmDashes();
 document.addEventListener('nav', function() {
-  setTimeout(initInteractive, 100);
+  setTimeout(function() { initInteractive(); replaceEmDashes(); }, 100);
 });
 `
 


### PR DESCRIPTION
## Summary
- Client-side script replaces em dashes (—) with semicolons in rendered article text
- Runs on all pages via the InteractiveGraphs afterDOMLoaded script
- Does not modify source markdown files in the vault
- Removes a common AI writing pattern marker

## Test plan
- [ ] Profile pages show semicolons instead of em dashes
- [ ] Landing page unaffected (JSX-generated, no em dashes)
- [ ] Links and code blocks not affected (only text nodes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)