### PR TITLE
Hide duplicate notices, fix mobile heading size

### DIFF
--- a/quartz/components/ProfileHeader.tsx
+++ b/quartz/components/ProfileHeader.tsx
@@ -135,6 +135,18 @@ function wrapProfileSections() {
   article.dataset.sectionsWrapped = 'true';
 }
 
+function hideDuplicateNotices() {
+  var article = document.querySelector('article');
+  if (!article) return;
+  var callouts = article.querySelectorAll('.callout');
+  for (var i = 0; i < callouts.length; i++) {
+    var title = callouts[i].querySelector('.callout-title-inner');
+    if (title && (title.textContent || '').indexOf('DUPLICATE') !== -1) {
+      callouts[i].style.display = 'none';
+    }
+  }
+}
+
 function hideDataviewFields() {
   var article = document.querySelector('article');
   if (!article) return;
@@ -151,10 +163,11 @@ function hideDataviewFields() {
 
 wrapProfileSections();
 hideDataviewFields();
+hideDuplicateNotices();
 document.addEventListener('nav', function() {
   var art = document.querySelector('article');
   if (art) art.dataset.sectionsWrapped = '';
-  setTimeout(function() { wrapProfileSections(); hideDataviewFields(); }, 100);
+  setTimeout(function() { wrapProfileSections(); hideDataviewFields(); hideDuplicateNotices(); }, 100);
 });
 `
 

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1521,7 +1521,7 @@ body[data-slug*="master-profile" i] {
       padding: 18px 16px;
       border-radius: 6px;
 
-      h2 {
+      h2, h3 {
         font-size: 18px !important;
       }
     }


### PR DESCRIPTION
## Summary
- Hides "DUPLICATE — DO NOT EDIT" callout notices on profile pages
- Fixes mobile CSS to target h3 headings (not just h2) in profile cards

## Test plan
- [ ] Pete Hegseth profile no longer shows duplicate warning
- [ ] Mobile profile cards have correct heading sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)