### PR TITLE
Redesign folder pages as card grids, expand sidebar categories

### DIFF
--- a/quartz/components/DonorMapSidebar.tsx
+++ b/quartz/components/DonorMapSidebar.tsx
@@ -130,10 +130,20 @@ const navTree: NavNode[] = [
   {
     name: "Media Pipeline",
     slugPrefix: "Media--and--Influence-Pipeline",
+    children: [
+      { name: "Right", slugPrefix: "Media--and--Influence-Pipeline/Right" },
+      { name: "Left", slugPrefix: "Media--and--Influence-Pipeline/Left" },
+      { name: "Centrist", slugPrefix: "Media--and--Influence-Pipeline/Centrist" },
+    ],
   },
   {
     name: "Think Tanks",
     slugPrefix: "Think-Tanks--and--Policy-Infrastructure",
+    children: [
+      { name: "Conservative", slugPrefix: "Think-Tanks--and--Policy-Infrastructure/Conservative" },
+      { name: "Liberal", slugPrefix: "Think-Tanks--and--Policy-Infrastructure/Liberal" },
+      { name: "Centrist", slugPrefix: "Think-Tanks--and--Policy-Infrastructure/Centrist" },
+    ],
   },
   {
     name: "K Street",

--- a/quartz/components/InteractiveGraphs.tsx
+++ b/quartz/components/InteractiveGraphs.tsx
@@ -685,10 +685,23 @@ function replaceEmDashes() {
   }
 }
 
+// Clean up folder page titles: "Folder: Lobbying-Firms--and--K-Street" → "Lobbying Firms & K Street"
+function cleanFolderTitle() {
+  var title = document.querySelector('.article-title');
+  if (!title) return;
+  var text = title.textContent || '';
+  if (text.indexOf('Folder:') !== 0) return;
+  text = text.replace('Folder: ', '');
+  text = text.replace(/--and--/g, ' & ');
+  text = text.replace(/-/g, ' ');
+  title.textContent = text;
+}
+
 initInteractive();
 replaceEmDashes();
+cleanFolderTitle();
 document.addEventListener('nav', function() {
-  setTimeout(function() { initInteractive(); replaceEmDashes(); }, 100);
+  setTimeout(function() { initInteractive(); replaceEmDashes(); cleanFolderTitle(); }, 100);
 });
 `
 

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -463,18 +463,96 @@ footer a {
 }
 
 // --- Folder listing pages ---
+.page-listing > p {
+  color: #63636e;
+  font-size: 0.82rem;
+  font-family: "Space Mono", monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 16px;
+}
+
+ul.section-ul {
+  margin-top: 12px !important;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+}
+
 .section-li {
-  border-bottom: 1px solid #1a1a22;
-  padding: 8px 0;
+  border-bottom: none;
+  padding: 0;
+  margin-bottom: 0 !important;
+}
+
+.section-li .section {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 6px;
+  background: #111118;
+  border: 1px solid #1e1e28;
+  border-radius: 8px;
+  padding: 16px 18px;
+  transition: border-color 0.2s, background 0.2s;
+  height: 100%;
+
+  &:hover {
+    border-color: rgba(99, 102, 241, 0.3);
+    background: #13131a;
+  }
+}
+
+.section-li .section .meta {
+  margin: 0 !important;
+  font-size: 0.72rem;
+  color: #53535e;
+  font-family: "Space Mono", monospace;
+}
+
+.section-li .section .desc {
+  flex: 1;
+}
+
+.section-li .section .desc h3 {
+  font-size: 0.92rem !important;
+  line-height: 1.3;
 }
 
 .section-li .section a {
   font-weight: 600;
-  color: #818cf8 !important;
+  color: #e4e4e7 !important;
+  text-decoration: none;
 }
 
 .section-li .section a:hover {
   color: #a5b4fc !important;
+}
+
+.section-li .section > .tags {
+  display: flex !important;
+  flex-wrap: wrap;
+  gap: 4px;
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0 0;
+
+  li {
+    margin: 0;
+  }
+
+  .tag-link {
+    display: inline-block;
+    background: rgba(99, 102, 241, 0.1);
+    color: #818cf8;
+    border: 1px solid rgba(99, 102, 241, 0.2);
+    border-radius: 3px;
+    padding: 1px 7px;
+    font-size: 0.65rem;
+    font-family: "Space Mono", monospace;
+    text-decoration: none;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+  }
 }
 
 // --- Horizontal rules ---


### PR DESCRIPTION
## Summary
- Folder listing pages redesigned from sparse rows to responsive card grid
- Tags display as inline pill badges instead of vertical bullet lists
- Folder titles humanized: removes "Folder:" prefix and converts slug hyphens
- Media Pipeline sidebar now expandable with Right/Left/Centrist subcategories
- Think Tanks sidebar now expandable with Conservative/Liberal/Centrist subcategories

## Test plan
- [ ] K Street folder page shows card grid layout
- [ ] Tags appear as inline pills on folder cards
- [ ] Folder title reads "Lobbying Firms & K Street" not "Folder: Lobbying-Firms--and--K-Street"
- [ ] Media Pipeline and Think Tanks expandable in sidebar
- [ ] Mobile folder pages responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)