### PR TITLE
Simplify folder listings to compact name-only grid

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -469,14 +469,14 @@ footer a {
   font-family: "Space Mono", monospace;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 16px;
+  margin-bottom: 12px;
 }
 
 ul.section-ul {
-  margin-top: 12px !important;
+  margin-top: 8px !important;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 8px;
 }
 
 .section-li {
@@ -486,36 +486,32 @@ ul.section-ul {
 }
 
 .section-li .section {
-  display: flex !important;
-  flex-direction: column !important;
-  gap: 6px;
+  display: block !important;
   background: #111118;
   border: 1px solid #1e1e28;
-  border-radius: 8px;
-  padding: 16px 18px;
+  border-radius: 6px;
+  padding: 12px 16px;
   transition: border-color 0.2s, background 0.2s;
-  height: 100%;
 
   &:hover {
-    border-color: rgba(99, 102, 241, 0.3);
-    background: #13131a;
+    border-color: rgba(99, 102, 241, 0.35);
+    background: #151520;
   }
 }
 
+// Hide dates and tags on folder listings — just show names
 .section-li .section .meta {
-  margin: 0 !important;
-  font-size: 0.72rem;
-  color: #53535e;
-  font-family: "Space Mono", monospace;
+  display: none;
 }
 
-.section-li .section .desc {
-  flex: 1;
+.section-li .section > .tags {
+  display: none !important;
 }
 
 .section-li .section .desc h3 {
-  font-size: 0.92rem !important;
+  font-size: 0.88rem !important;
   line-height: 1.3;
+  margin: 0;
 }
 
 .section-li .section a {
@@ -526,33 +522,6 @@ ul.section-ul {
 
 .section-li .section a:hover {
   color: #a5b4fc !important;
-}
-
-.section-li .section > .tags {
-  display: flex !important;
-  flex-wrap: wrap;
-  gap: 4px;
-  list-style: none;
-  padding: 0;
-  margin: 4px 0 0 0;
-
-  li {
-    margin: 0;
-  }
-
-  .tag-link {
-    display: inline-block;
-    background: rgba(99, 102, 241, 0.1);
-    color: #818cf8;
-    border: 1px solid rgba(99, 102, 241, 0.2);
-    border-radius: 3px;
-    padding: 1px 7px;
-    font-size: 0.65rem;
-    font-family: "Space Mono", monospace;
-    text-decoration: none;
-    text-transform: uppercase;
-    letter-spacing: 0.02em;
-  }
 }
 
 // --- Horizontal rules ---


### PR DESCRIPTION
## Summary
- Hide tags and dates on folder listing pages
- Compact card grid with just names (200px min width)
- Much easier to scan and navigate

## Test plan
- [ ] Media Pipeline/Right shows clean grid of names
- [ ] K Street shows clean grid of names
- [ ] Cards highlight on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)