### PR TITLE
Hide internal docs from build, fix dataview fields on all pages

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -15,7 +15,7 @@ const config: QuartzConfig = {
     analytics: null,
     locale: "en-US",
     baseUrl: "guerillapropaganda.github.io/donor-map-site",
-    ignorePatterns: ["private", "templates", ".obsidian", "_templates", "Vault Maintenance", "Excalidraw", "Assets", "DRAFT-*", "publish.css", "_VAULT_INDEX.md"],
+    ignorePatterns: ["private", "templates", ".obsidian", "_templates", "Vault Maintenance", "Excalidraw", "Assets", "DRAFT-*", "publish.css", "_VAULT_INDEX.md", "Stories/Internal", "Interactive"],
     defaultDateType: "modified",
     theme: {
       fontOrigin: "googleFonts",

--- a/quartz/components/ProfileHeader.tsx
+++ b/quartz/components/ProfileHeader.tsx
@@ -150,8 +150,6 @@ function hideDuplicateNotices() {
 function hideDataviewFields() {
   var article = document.querySelector('article');
   if (!article) return;
-  var slug = (document.body.dataset.slug || '').toLowerCase();
-  if (slug.indexOf('master-profile') === -1) return;
   var ps = article.querySelectorAll('p');
   for (var i = 0; i < ps.length; i++) {
     var t = ps[i].textContent || '';


### PR DESCRIPTION
## Summary
- Stories/Internal excluded from build (research logs, daily updates are private)
- Interactive folder excluded from build (unused, clutters mobile explorer)
- Dataview inline fields (content-readiness::, etc.) now hidden on ALL pages, not just profiles

## Test plan
- [ ] Stories/Internal no longer accessible or visible in explorer
- [ ] Interactive folder gone from mobile explorer
- [ ] "content-readiness:: ready" no longer visible on any page
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)