### PR TITLE
Boost mobile text contrast for readability

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -622,12 +622,41 @@ hr {
     color: #4ade80 !important;   // brighter green
   }
 
-  // GREY/MUTED text — brighter on mobile
+  // GREY/MUTED text — brighter on mobile for readability
   .content-meta,
   .breadcrumb-container,
   .dm-subtitle,
   .dm-section-label {
-    color: #8a8a96 !important;   // brighter than #63636e
+    color: #9a9aaa !important;
+  }
+
+  // Folder listing count, dates, all muted text
+  .page-listing > p,
+  .section-li .section .meta,
+  .folder-title,
+  .meta,
+  time {
+    color: #9a9aaa !important;
+  }
+
+  // General body text baseline — catch anything still too dim
+  article, .popover-hint {
+    color: #d0d0d8 !important;
+  }
+
+  // Links should pop on mobile
+  a.internal {
+    color: #a5b4fc !important;
+  }
+
+  // Callout text
+  .callout {
+    color: #c8c8d0 !important;
+  }
+
+  // Footer, breadcrumbs
+  footer, footer a, .breadcrumb-element {
+    color: #8a8a96 !important;
   }
 
   // Tables: compact fit, no overflow


### PR DESCRIPTION
## Summary
- Brightened all muted/grey text on mobile (body, meta, dates, links, callouts, breadcrumbs)
- Desktop colors completely unchanged
- Mobile body text now #d0d0d8, links #a5b4fc, muted elements #9a9aaa

## Test plan
- [ ] Mobile text noticeably brighter and easier to read
- [ ] Desktop appearance unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)