### PR TITLE
Fix dataview fields still showing on some pages

### DIFF
--- a/quartz/components/ProfileHeader.tsx
+++ b/quartz/components/ProfileHeader.tsx
@@ -152,8 +152,8 @@ function hideDataviewFields() {
   if (!article) return;
   var ps = article.querySelectorAll('p');
   for (var i = 0; i < ps.length; i++) {
-    var t = ps[i].textContent || '';
-    if (t.match(/^[a-z-]+::\s/)) {
+    var t = (ps[i].textContent || '').trim();
+    if (t.match(/[a-z-]+::\s/)) {
       ps[i].style.display = 'none';
     }
   }


### PR DESCRIPTION
## Summary
- Match `key:: value` pattern anywhere in paragraph text, not just at the start
- Trim whitespace before matching
- Catches research-status::, content-readiness:: that appear mid-text or with leading spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)