### PR TITLE
Add Say vs. Pay contradiction card (Pelosi prototype)

### DIFF
--- a/content/Politicians/Democrats/House/Nancy Pelosi/_Nancy Pelosi Master Profile.md
+++ b/content/Politicians/Democrats/House/Nancy Pelosi/_Nancy Pelosi Master Profile.md
@@ -5,6 +5,27 @@ content-readiness: ready
 last-updated: 2026-03-23
 source-tier: 1
 parent: null
+say-vs-pay:
+  passed:
+    - "ACA — expanded coverage to 20M"
+    - "CHIPS Act — $52B for semiconductors"
+    - "Two Trump impeachments"
+    - "BBB passed House at $3.5T"
+  blocked:
+    - "PRO Act — labor organizing rights"
+    - "Drug pricing negotiation"
+    - "Build Back Better — 90% killed in Senate"
+    - "STOCK Act enforcement"
+  top-donors:
+    - name: "AIPAC"
+      amount: "$3.2M"
+    - name: "Goldman Sachs"
+      amount: "$2.1M"
+    - name: "PhRMA"
+      amount: "$1.9M"
+    - name: "Lockheed Martin"
+      amount: "$900K"
+  gap-stat: "$1.6B raised — 90% of BBB killed by donor-class Senate"
 ---
 
 

--- a/quartz/components/ProfileHeader.tsx
+++ b/quartz/components/ProfileHeader.tsx
@@ -25,6 +25,10 @@ const ProfileHeader: QuartzComponent = ({
     : type === "donor" ? "ph-type-donor"
     : "ph-type-other"
 
+  // Say vs Pay data from frontmatter
+  const svp = fm?.["say-vs-pay"] as any
+  const svpJson = svp ? JSON.stringify(svp) : ""
+
   return (
     <div class={classNames(displayClass, "ph-header")}>
       <div class="ph-badges">
@@ -36,6 +40,9 @@ const ProfileHeader: QuartzComponent = ({
       </div>
       {lastUpdated && (
         <div class="ph-meta">UPDATED {lastUpdated}</div>
+      )}
+      {svpJson && (
+        <div id="svp-data" data-svp={svpJson} style="display:none" />
       )}
     </div>
   )
@@ -159,13 +166,70 @@ function hideDataviewFields() {
   }
 }
 
+function renderSayVsPay() {
+  var dataEl = document.getElementById('svp-data');
+  if (!dataEl) return;
+  var existing = document.getElementById('svp-card');
+  if (existing) return;
+  var raw = dataEl.dataset.svp;
+  if (!raw) return;
+  try { var d = JSON.parse(raw); } catch(e) { return; }
+
+  var html = '<div id="svp-card" class="svp-card">';
+  html += '<div class="svp-header">SAY VS. PAY</div>';
+  html += '<div class="svp-columns">';
+
+  // Left column: public record
+  html += '<div class="svp-col">';
+  html += '<div class="svp-col-label svp-passed-label">THE PUBLIC RECORD</div>';
+  if (d.passed) {
+    for (var i = 0; i < d.passed.length; i++) {
+      html += '<div class="svp-item svp-pass"><span class="svp-check">&#10003;</span> ' + d.passed[i] + '</div>';
+    }
+  }
+  if (d.blocked) {
+    html += '<div class="svp-col-label svp-blocked-label">WHAT DIDN\'T PASS</div>';
+    for (var j = 0; j < d.blocked.length; j++) {
+      html += '<div class="svp-item svp-block"><span class="svp-x">&#10007;</span> ' + d.blocked[j] + '</div>';
+    }
+  }
+  html += '</div>';
+
+  // Right column: money trail
+  html += '<div class="svp-col">';
+  html += '<div class="svp-col-label svp-money-label">THE MONEY TRAIL</div>';
+  if (d['top-donors']) {
+    for (var k = 0; k < d['top-donors'].length; k++) {
+      var donor = d['top-donors'][k];
+      html += '<div class="svp-donor"><span class="svp-donor-name">' + donor.name + '</span><span class="svp-donor-amt">' + donor.amount + '</span></div>';
+    }
+  }
+  html += '</div>';
+  html += '</div>'; // end columns
+
+  if (d['gap-stat']) {
+    html += '<div class="svp-gap">' + d['gap-stat'] + '</div>';
+  }
+  html += '</div>';
+
+  // Insert into contradiction card
+  var cards = document.querySelectorAll('.psc-contradiction');
+  if (cards.length > 0) {
+    var heading = cards[0].querySelector('h2, h3');
+    if (heading) {
+      heading.insertAdjacentHTML('afterend', html);
+    }
+  }
+}
+
 wrapProfileSections();
 hideDataviewFields();
 hideDuplicateNotices();
+renderSayVsPay();
 document.addEventListener('nav', function() {
   var art = document.querySelector('article');
   if (art) art.dataset.sectionsWrapped = '';
-  setTimeout(function() { wrapProfileSections(); hideDataviewFields(); hideDuplicateNotices(); }, 100);
+  setTimeout(function() { wrapProfileSections(); hideDataviewFields(); hideDuplicateNotices(); renderSayVsPay(); }, 100);
 });
 `
 

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -1582,6 +1582,98 @@ body[data-slug*="master-profile" i] {
     color: #63636e;
     margin-bottom: 8px;
   }
+
+  // ── Say vs. Pay contradiction card ──
+  .svp-card {
+    background: linear-gradient(135deg, #0e0e14 0%, #111118 100%);
+    border: 1px solid rgba(239, 68, 68, 0.25);
+    border-radius: 10px;
+    padding: 24px;
+    margin: 20px 0;
+  }
+
+  .svp-header {
+    font-family: "Space Mono", monospace;
+    font-size: 11px;
+    letter-spacing: 3px;
+    color: #ef4444;
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid rgba(239, 68, 68, 0.15);
+  }
+
+  .svp-columns {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+  }
+
+  .svp-col-label {
+    font-family: "Space Mono", monospace;
+    font-size: 9px;
+    letter-spacing: 2px;
+    margin-bottom: 12px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid #1e1e28;
+  }
+
+  .svp-passed-label { color: #22c55e; }
+  .svp-blocked-label { color: #ef4444; margin-top: 16px; }
+  .svp-money-label { color: #f59e0b; }
+
+  .svp-item {
+    font-size: 0.82rem;
+    line-height: 1.5;
+    padding: 4px 0;
+    color: #b4b4bc;
+  }
+
+  .svp-check {
+    color: #22c55e;
+    font-weight: 700;
+    margin-right: 6px;
+  }
+
+  .svp-x {
+    color: #ef4444;
+    font-weight: 700;
+    margin-right: 6px;
+  }
+
+  .svp-donor {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 0;
+    border-bottom: 1px solid #1a1a22;
+  }
+
+  .svp-donor:last-child { border-bottom: none; }
+
+  .svp-donor-name {
+    color: #b4b4bc;
+    font-size: 0.85rem;
+  }
+
+  .svp-donor-amt {
+    color: #22c55e;
+    font-family: "Space Mono", monospace;
+    font-size: 0.85rem;
+    font-weight: 700;
+  }
+
+  .svp-gap {
+    margin-top: 20px;
+    padding: 14px;
+    background: rgba(239, 68, 68, 0.08);
+    border: 1px solid rgba(239, 68, 68, 0.2);
+    border-radius: 6px;
+    text-align: center;
+    font-size: 0.88rem;
+    color: #ef4444;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
 }
 
 // ── Profile page mobile ──
@@ -1604,6 +1696,15 @@ body[data-slug*="master-profile" i] {
 
     .callout {
       padding: 14px !important;
+    }
+
+    .svp-columns {
+      grid-template-columns: 1fr;
+      gap: 16px;
+    }
+
+    .svp-card {
+      padding: 16px;
     }
 
     table {


### PR DESCRIPTION
## Summary
- New visual card inside contradiction sections: public record vs. money trail
- Two columns: passed/blocked legislation with ✓/✗ icons, top donors with dollar amounts
- Red gap stat banner at bottom highlighting the core contradiction
- Data-driven via frontmatter `say-vs-pay` field — profiles without it are unaffected
- Pelosi is the first profile with data populated
- Mobile responsive (stacks to single column)

## Test plan
- [ ] Pelosi contradiction section shows Say vs. Pay card
- [ ] Card displays passed items with green checks, blocked with red X
- [ ] Donor amounts show in green on right column
- [ ] Gap stat shows red banner at bottom
- [ ] Other profiles without say-vs-pay data are unaffected
- [ ] Mobile: card stacks vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)