### PR TITLE
Exclude internal files, READMEs, and sensitive content from build

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -15,7 +15,7 @@ const config: QuartzConfig = {
     analytics: null,
     locale: "en-US",
     baseUrl: "guerillapropaganda.github.io/donor-map-site",
-    ignorePatterns: ["private", "templates", ".obsidian", "_templates", "Vault Maintenance", "Excalidraw", "Assets", "DRAFT-*", "publish.css", "_VAULT_INDEX.md", "Stories/Internal", "Interactive"],
+    ignorePatterns: ["private", "templates", ".obsidian", "_templates", "Vault Maintenance", "Excalidraw", "Assets", "DRAFT-*", "publish.css", "_VAULT_INDEX.md", "**/Internal/**", "Interactive", "**/_README*", "**/README*", "**/Jeffrey Epstein*", "**/Daily Updates/**"],
     defaultDateType: "modified",
     theme: {
       fontOrigin: "googleFonts",


### PR DESCRIPTION
## Summary
- Hide all Internal folders, README files, Daily Updates, and Jeffrey Epstein network from build
- Uses glob patterns for broader matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)