### PR TITLE
Add interactive graph view showing page connections

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -49,6 +49,25 @@ export const defaultContentPageLayout: PageLayout = {
   ],
   right: [
     Component.DesktopOnly(Component.Search()),
+    Component.DesktopOnly(Component.Graph({
+      localGraph: {
+        depth: 2,
+        repelForce: 0.6,
+        centerForce: 0.3,
+        linkDistance: 40,
+        fontSize: 0.5,
+        focusOnHover: true,
+        showTags: false,
+      },
+      globalGraph: {
+        depth: -1,
+        repelForce: 0.4,
+        centerForce: 0.25,
+        linkDistance: 50,
+        fontSize: 0.5,
+        showTags: false,
+      },
+    })),
     Component.DesktopOnly(Component.TableOfContents()),
     Component.DesktopOnly(Component.ProfileWidget()),
     Component.Backlinks(),

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -550,6 +550,26 @@ hr {
   background: #2a2a36;
 }
 
+// --- Graph view ---
+.graph > h3 {
+  color: #63636e;
+  font-family: "Space Mono", monospace;
+  font-size: 10px !important;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+.graph > .graph-outer {
+  border-color: #1e1e28;
+  background: #0c0c0f;
+  height: 300px;
+}
+
+.global-graph-outer > .global-graph-container {
+  background-color: #0c0c0f !important;
+  border-color: #1e1e28 !important;
+}
+
 // --- Selection ---
 ::selection {
   background: rgba(99, 102, 241, 0.3);


### PR DESCRIPTION
## Summary
- Enables Quartz's D3-powered graph component in the right sidebar
- Local graph shows 2 levels of connections with focus-on-hover highlighting
- Click expand icon for full-screen global graph with all nodes
- Drag, zoom, click nodes to navigate
- Styled for dark theme

## Test plan
- [ ] Graph appears in right sidebar on desktop
- [ ] Hover highlights connected nodes
- [ ] Click node navigates to that page
- [ ] Global graph opens full-screen
- [ ] Dark theme colors match site

🤖 Generated with [Claude Code](https://claude.com/claude-code)