### PR TITLE
Make mobile section headers red for visibility

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -603,10 +603,12 @@ hr {
     font-size: 19px !important;
     margin-top: 32px;
     padding-left: 10px;
+    color: #ef4444 !important;
   }
 
   article h3 {
     font-size: 10px !important;
+    color: #ef4444 !important;
   }
 
   // BIGGER body text on mobile — easier to read


### PR DESCRIPTION
## Summary
- H2 and H3 headers on mobile now render in red (#ef4444)
- Desktop headers unchanged
- Improves readability on phone screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)