### PR TITLE
Reduce global graph to depth 1 — page connections only

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -60,7 +60,7 @@ export const defaultContentPageLayout: PageLayout = {
         showTags: false,
       },
       globalGraph: {
-        depth: 2,
+        depth: 1,
         repelForce: 0.3,
         centerForce: 0.4,
         linkDistance: 30,


### PR DESCRIPTION
## Summary
- Global graph (expanded view) reduced from depth 2 to depth 1
- Now shows only the current page's direct connections, same scope as the sidebar graph but in a larger viewport
- Eliminates lag on heavily-connected profiles like Pelosi, Trump, etc.

## Test plan
- [ ] Open a profile page, click the graph expand icon — should show only direct connections
- [ ] Verify no lag on heavily-connected profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)