### PR TITLE
Add footer nav links + bigger mobile headers

### DIFF
--- a/quartz/components/Footer.tsx
+++ b/quartz/components/Footer.tsx
@@ -7,12 +7,34 @@ interface Options {
   links: Record<string, string>
 }
 
+const siteNavLinks = [
+  { text: "Politicians", slug: "Politicians" },
+  { text: "Donors & Power Networks", slug: "Donors--and--Power-Networks" },
+  { text: "Investigations", slug: "Stories" },
+  { text: "Lobbyists & K Street", slug: "Lobbying-Firms--and--K-Street" },
+  { text: "Media Pipeline", slug: "Media-Pipeline" },
+  { text: "Think Tanks", slug: "Think-Tanks" },
+  { text: "Guided Tour", slug: "Stories/Follow-the-Money---Guided-Tour" },
+  { text: "Browse by Pattern", slug: "Stories/Browse-by-Pattern" },
+  { text: "About", slug: "About-the-Donor-Map" },
+  { text: "Methodology", slug: "Methodology" },
+]
+
 export default ((opts?: Options) => {
   const Footer: QuartzComponent = ({ displayClass, cfg }: QuartzComponentProps) => {
     const year = new Date().getFullYear()
     const links = opts?.links ?? []
+    const baseUrl = cfg.baseUrl ?? ""
+    const slashIdx = baseUrl.indexOf("/")
+    const basePath = slashIdx >= 0 ? "/" + baseUrl.substring(slashIdx + 1) : ""
+
     return (
       <footer class={`${displayClass ?? ""}`}>
+        <nav class="footer-site-nav">
+          {siteNavLinks.map((link) => (
+            <a href={`${basePath}/${link.slug}`}>{link.text}</a>
+          ))}
+        </nav>
         <p>
           {i18n(cfg.locale).components.footer.createdWith}{" "}
           <a href="https://quartz.jzhao.xyz/">Quartz v{version}</a> © {year}

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -453,13 +453,39 @@ footer {
   font-size: 11px;
 }
 
-footer > p:first-child {
+.footer-site-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+  padding: 16px 0;
+  margin-bottom: 12px;
+  border-bottom: 1px solid #1e1e28;
+
+  a {
+    color: #818cf8 !important;
+    font-size: 12px;
+    font-weight: 500;
+    text-decoration: none !important;
+    white-space: nowrap;
+    transition: color 0.15s;
+
+    &:hover {
+      color: #a5b4fc !important;
+    }
+  }
+}
+
+footer > p:first-of-type {
   opacity: 0.4;
   font-size: 10px;
 }
 
 footer a {
   color: #63636e !important;
+}
+
+.footer-site-nav a {
+  color: #818cf8 !important;
 }
 
 // --- Folder listing pages ---
@@ -600,15 +626,17 @@ hr {
   }
 
   article h2 {
-    font-size: 19px !important;
+    font-size: 22px !important;
     margin-top: 32px;
     padding-left: 10px;
     color: #ef4444 !important;
+    font-weight: 700 !important;
   }
 
   article h3 {
-    font-size: 10px !important;
+    font-size: 16px !important;
     color: #ef4444 !important;
+    font-weight: 600 !important;
   }
 
   // BIGGER body text on mobile — easier to read


### PR DESCRIPTION
## Summary
- Added site-wide navigation bar in footer with links to: Politicians, Donors & Power Networks, Investigations, K Street, Media Pipeline, Think Tanks, Guided Tour, Browse by Pattern, About, Methodology
- Increased mobile h2 from 19px to 22px (bold) and h3 from 10px to 16px (semi-bold) for better readability

## Test plan
- [ ] Check footer on any page — nav links appear above the "created with Quartz" line
- [ ] Check mobile — headers are larger and more readable
- [ ] Verify nav links point to correct sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)