### PR TITLE
Hide global graph — keep local sidebar graph only

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -591,9 +591,13 @@ hr {
   height: 300px;
 }
 
-.global-graph-outer > .global-graph-container {
-  background-color: #0c0c0f !important;
-  border-color: #1e1e28 !important;
+// Hide global graph — too many nodes for this vault size
+.global-graph-icon {
+  display: none !important;
+}
+
+.global-graph-outer {
+  display: none !important;
 }
 
 // --- Selection ---


### PR DESCRIPTION
## Summary
- Hides the global graph expand button and overlay
- The sidebar local graph (depth 1, showing page's direct connections) remains — it's useful and performant
- The fullscreen global view consistently shows too many nodes for a 1,400+ profile vault

## Test plan
- [ ] Graph still shows in sidebar with local connections
- [ ] No expand icon visible
- [ ] No fullscreen graph overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)