### PR TITLE
Fix backlinks getting cut off at sidebar edge

### DIFF
--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -401,8 +401,9 @@ strong > code, b > code {
 // --- Backlinks ---
 .backlinks {
   border-top: 1px solid #1e1e28;
-  margin-top: 48px;
-  padding-top: 24px;
+  margin-top: 16px;
+  padding-top: 16px;
+  padding-bottom: 2rem;
 }
 
 .backlinks > h3 {


### PR DESCRIPTION
## Summary
- Reduced backlinks margin-top from 48px to 16px to scoot them up
- Added bottom padding so the full backlinks list is visible

## Test plan
- [ ] Backlinks section fully visible in right sidebar without being clipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)