### PR TITLE
Rename logo to The Donor Map$

### DIFF
--- a/quartz/components/DonorMapSidebar.tsx
+++ b/quartz/components/DonorMapSidebar.tsx
@@ -282,7 +282,7 @@ const DonorMapSidebar: QuartzComponent = ({
       <div class="dm-logo">
         <a href={absHref("")}>
           <span class="dm-logo-dm">DM</span>
-          <span class="dm-logo-text"> Donor Map<span class="dm-cursor">$</span></span>
+          <span class="dm-logo-text"> The Donor Map<span class="dm-cursor">$</span></span>
         </a>
         <div class="dm-subtitle">v2.0 — {allFiles.length.toLocaleString()} nodes tracked</div>
       </div>

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -667,7 +667,7 @@ hr {
 @media (max-width: 800px) {
   // Site name at top of mobile pages
   .page-header::before {
-    content: "Donor Map$";
+    content: "The Donor Map$";
     display: block;
     font-family: 'Space Grotesk', sans-serif;
     font-size: 18px;


### PR DESCRIPTION
## Summary
- Logo text changed from "Donor Map$" to "The Donor Map$" in both desktop sidebar and mobile header

🤖 Generated with [Claude Code](https://claude.com/claude-code)