### PR TITLE
Add related profiles, search badges, OG images, biggest findings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -35,7 +35,24 @@
       "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge --repo Guerillapropaganda/donor-map-site --merge)",
       "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 33 --repo Guerillapropaganda/donor-map-site --merge)",
       "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 34 --repo Guerillapropaganda/donor-map-site --merge)",
-      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 35 --repo Guerillapropaganda/donor-map-site --merge)"
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 35 --repo Guerillapropaganda/donor-map-site --merge)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 36 --repo Guerillapropaganda/donor-map-site --merge)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 37 --repo Guerillapropaganda/donor-map-site --merge)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 38 --repo Guerillapropaganda/donor-map-site --merge)",
+      "Bash(xargs -I {} grep -l \"^\\\\|\" {})",
+      "Bash(grep -r \"dataview\\\\|dataviewjs\" /c/Users/third/donor-map-site/.claude/worktrees/elated-borg/content --include=*.md)",
+      "Bash(grep -A 20 '```dataview' \"/c/Users/third/donor-map-site/.claude/worktrees/elated-borg/content/Politicians/Democrats/House/Ayanna Pressley/_Ayanna Pressley Master Profile.md\")",
+      "Bash(find /c/Users/third/donor-map-site/.claude/worktrees/elated-borg/content -name *.md -type f -exec grep -l \"^\\\\| .* \\\\|\" {})",
+      "Bash(2)",
+      "Bash(grep -r class= /c/Users/third/donor-map-site/.claude/worktrees/elated-borg/content --include=*.md)",
+      "Bash(grep -r '{: \\\\.' /c/Users/third/donor-map-site/.claude/worktrees/elated-borg/content --include=*.md)",
+      "Bash(grep -r \"^\\\\|\" /c/Users/third/donor-map-site/.claude/worktrees/elated-borg/content --include=*.md)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 39 --repo Guerillapropaganda/donor-map-site --merge)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr list --repo Guerillapropaganda/donor-map-site --state open --json number,title)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 40 --repo Guerillapropaganda/donor-map-site --merge)",
+      "Bash(find /c/Users/third/donor-map-site/.claude/worktrees/elated-borg/quartz/static -name og-image* -o -name icon.png)",
+      "Bash(find C:Usersthirddonor-map-site.claudeworktreeselated-borgcontentStoriesPublished -type f -name *.md -o -name *.json)",
+      "Bash(find 'C:\\\\Users\\\\third\\\\donor-map-site\\\\.claude\\\\worktrees\\\\elated-borg\\\\content\\\\Stories\\\\Published\\\\Contradiction Deep Dives' -type f -name *.md)"
     ]
   }
 }

--- a/content/Stories/Published/The Biggest Findings.md
+++ b/content/Stories/Published/The Biggest Findings.md
@@ -1,0 +1,113 @@
+---
+title: "The Biggest Findings"
+type: sub-note
+content-readiness: developed
+last-updated: 2026-04-02
+source-tier: 1
+---
+
+#featured #findings #contradictions #both-sides #donor-class #follow-the-money
+
+---
+
+### The Core Discovery
+
+Every investigation in this database points to the same structural reality: **when two politicians funded by the same donor perform public opposition, the conflict is theater.** The donor wins either way.
+
+This page collects the ten most damning examples. Each one is sourced, documented, and traceable through the database.
+
+---
+
+### 1. Goldman Sachs Funds Both Sides of Financial Regulation
+
+Trump attacked Goldman Sachs as the symbol of Wall Street corruption. Then he appointed four Goldman executives to his cabinet. Democrats take Goldman money and promise regulation. Neither side delivers. The same donor wins regardless of who holds power.
+
+[[Contradiction 01 - Goldman Sachs Funds Both Sides of Financial Regulation|Read the full investigation]]
+
+---
+
+### 2. AIPAC Locks Bipartisan Israel Policy
+
+Republicans and Democrats wage scorched-earth battles on healthcare, taxes, immigration, and labor. On Israel policy, the vote is 97-3. AIPAC funds both sides, and the result is ironclad bipartisan consensus that no amount of public opposition can break.
+
+[[Contradiction 02 - AIPAC Locks Bipartisan Israel Policy While Politicians Fight on Everything Else|Read the full investigation]]
+
+---
+
+### 3. PhRMA Kills Drug Pricing From Both Sides
+
+Democrats claim to fight for affordable healthcare. Republicans oppose price controls on principle. Yet both parties block Medicare drug price negotiation because pharmaceutical manufacturers donate to both. The public pays; the donors profit.
+
+[[Contradiction 03 - PhRMA Kills Drug Negotiation From Both Sides|Read the full investigation]]
+
+---
+
+### 4. Lockheed Martin Buys Defense Hawks in Both Parties
+
+Kay Granger (R) and Rosa DeLauro (D) attack each other on every domestic issue. On defense spending, they vote in perfect harmony. Lockheed Martin donates to both. The defense budget grows regardless of which party controls Congress.
+
+[[Contradiction 04 - Lockheed Martin Buys Defense Hawks in Both Parties|Read the full investigation]]
+
+---
+
+### 5. The Cuba Fuel Blockade
+
+On March 16, 2026, Cuba's power grid collapsed. Ten million people went dark. Secretary of State Rubio managed the fuel blockade. His career was funded by the Fanjul sugar dynasty, the family that directly benefits from eliminating Cuban agricultural competition. The policy wasn't ideology. It was a return on investment.
+
+[[Operation Southern Spear and the Cuba Fuel Blockade|Read the full investigation]]
+
+---
+
+### 6. The Nuestra America Convoy
+
+650 people from 33 nations delivered humanitarian aid to Cuba. Within 72 hours, the donor class that profits from the embargo launched a coordinated media-political attack. The same politicians who receive anti-Cuba lobby money led the charge. The donors defended the blockade; the media manufactured consent.
+
+[[The Nuestra America Convoy - How the Donor Class Attacked a Humanitarian Mission|Read the full investigation]]
+
+---
+
+### 7. Koch vs Soros: Mirror Image Dark Money
+
+Charles Koch and George Soros run parallel dark money networks that publicly condemn each other. Both use identical structures: shell foundations, 501(c)(4)s, donor-advised funds. The left-right war is real for voters. For the donor class, it's infrastructure.
+
+[[Contradiction 08 - Koch vs Soros Mirror Image Dark Money Machines|Read the full investigation]]
+
+---
+
+### 8. Tech Monopolies Buy Antitrust Protection
+
+Bipartisan antitrust bills had 76-80% public support and White House endorsement. They died in 2022 when Senate Majority Leader Schumer blocked a floor vote. His daughter works at Meta, one of the bill's primary targets. The donor class overrode supermajority public opinion.
+
+[[Contradiction 20 - Tech Monopolies Buy Antitrust Protection From Both Parties|Read the full investigation]]
+
+---
+
+### 9. Defense Contractors: 450,000% ROI
+
+The defense industry's political spending generates returns that would be illegal in any other market. Millions in donations produce billions in contracts. The math is simple: invest in politicians, extract from taxpayers. Both parties participate. Neither side objects.
+
+[[Defense Contractor 450000 Percent ROI|Read the full investigation]]
+
+---
+
+### 10. The Both-Sides Illusion
+
+The cross-politician contradiction map lays it all out: the same donors funding both parties, the same policy outcomes regardless of election results, the same money flowing through the same channels. The two-party system isn't broken. It's working exactly as the donor class designed it.
+
+[[Cross-Politician Contradiction Map - The Both-Sides Illusion With Receipts|Read the full investigation]]
+
+---
+
+### What These Findings Mean
+
+These aren't isolated cases. They're the pattern. Every sector, every policy area, every election cycle, the same structure repeats: donors invest in both sides, politicians perform opposition, and the policy outcome serves the funder.
+
+The database tracks this across 1,400+ profiles. Start with any politician. Follow their donors. Find the same donors funding their opponents. Check the policy outcomes. The pattern holds every time.
+
+---
+
+### Where to Go Next
+
+- [[Follow the Money - Guided Tour|Take the Guided Tour]] - nine curated trails through the database
+- [[Browse by Pattern]] - find more examples of these structural patterns
+- [[Cross-Politician Contradiction Map - The Both-Sides Illusion With Receipts|The Both-Sides Illusion]] - the full cross-politician analysis

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -86,8 +86,9 @@ const config: QuartzConfig = {
       Plugin.Static(),
       Plugin.Favicon(),
       Plugin.NotFoundPage(),
-      // Comment out CustomOgImages to speed up build time
-      // Plugin.CustomOgImages(),
+      Plugin.CustomOgImages({
+        colorScheme: "darkMode",
+      }),
     ],
   },
 }

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -71,6 +71,7 @@ export const defaultContentPageLayout: PageLayout = {
     Component.DesktopOnly(Component.TableOfContents()),
     Component.DesktopOnly(Component.ProfileWidget()),
     Component.Backlinks(),
+    Component.RelatedProfiles(),
   ],
 }
 

--- a/quartz/components/LandingPage.tsx
+++ b/quartz/components/LandingPage.tsx
@@ -288,6 +288,12 @@ const LandingPage: QuartzComponent = ({
               Nine curated trails — Cuba blockade, Wall Street, defense, pharma, dark money, the Supreme Court, Trump Cabinet, consent machine, Israel Lobby.
             </div>
           </a>
+          <a href={getHref("the-biggest-findings")} class="lp-start-card lp-start-primary">
+            <div class="lp-start-card-title">The Biggest Findings</div>
+            <div class="lp-start-card-desc">
+              The 10 most damning contradictions. Same donors, both parties, same outcomes. Start here.
+            </div>
+          </a>
           <a href={getHref("browse-by-pattern")} class="lp-start-card">
             <div class="lp-start-card-title">Browse by Pattern</div>
             <div class="lp-start-card-desc">

--- a/quartz/components/RelatedProfiles.tsx
+++ b/quartz/components/RelatedProfiles.tsx
@@ -1,0 +1,181 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import { resolveRelative, simplifySlug } from "../util/path"
+import { classNames } from "../util/lang"
+
+const RelatedProfiles: QuartzComponent = ({
+  fileData,
+  allFiles,
+  displayClass,
+}: QuartzComponentProps) => {
+  const slug = simplifySlug(fileData.slug!)
+  const currentLinks = new Set(fileData.links ?? [])
+
+  if (currentLinks.size === 0) return null
+
+  // Find pages that share the most outgoing links with the current page
+  const scored = allFiles
+    .filter((f) => {
+      const fSlug = simplifySlug(f.slug!)
+      // Skip self, index pages, and folder pages
+      if (fSlug === slug) return false
+      if (fSlug === "index" || fSlug.endsWith("/index")) return false
+      return true
+    })
+    .map((f) => {
+      const fLinks = new Set(f.links ?? [])
+      let shared = 0
+      for (const link of fLinks) {
+        if (currentLinks.has(link)) shared++
+      }
+      return { file: f, shared }
+    })
+    .filter(({ shared }) => shared >= 2) // need at least 2 shared links
+    .sort((a, b) => b.shared - a.shared)
+    .slice(0, 8) // top 8
+
+  if (scored.length === 0) return null
+
+  // Determine content type from slug
+  function getType(s: string): string {
+    const lower = s.toLowerCase()
+    if (lower.startsWith("politicians/")) return "POLITICIAN"
+    if (lower.startsWith("donors")) return "DONOR"
+    if (lower.startsWith("stories/")) return "STORY"
+    if (lower.startsWith("lobbying") || lower.startsWith("k-street")) return "K STREET"
+    if (lower.startsWith("media")) return "MEDIA"
+    if (lower.startsWith("think")) return "THINK TANK"
+    return ""
+  }
+
+  function getTypeClass(type: string): string {
+    switch (type) {
+      case "POLITICIAN": return "rp-type-pol"
+      case "DONOR": return "rp-type-donor"
+      case "STORY": return "rp-type-story"
+      default: return "rp-type-other"
+    }
+  }
+
+  return (
+    <div class={classNames(displayClass, "related-profiles")}>
+      <h3>Related Profiles</h3>
+      <p class="rp-subtitle">Pages sharing the most connections with this one</p>
+      <ul class="rp-list">
+        {scored.map(({ file, shared }) => {
+          const type = getType(file.slug ?? "")
+          return (
+            <li class="rp-item">
+              <a href={resolveRelative(fileData.slug!, file.slug!)} class="internal rp-link">
+                {type && <span class={`rp-badge ${getTypeClass(type)}`}>{type}</span>}
+                <span class="rp-name">{file.frontmatter?.title ?? file.slug}</span>
+                <span class="rp-shared">{shared} shared</span>
+              </a>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+RelatedProfiles.css = `
+.related-profiles {
+  border-top: 1px solid #1e1e28;
+  margin-top: 16px;
+  padding-top: 16px;
+}
+
+.related-profiles > h3 {
+  font-family: 'Space Mono', monospace !important;
+  font-size: 11px !important;
+  letter-spacing: 2px !important;
+  text-transform: uppercase !important;
+  color: #63636e !important;
+  margin-bottom: 4px;
+}
+
+.rp-subtitle {
+  font-size: 10px;
+  color: #4a4a54;
+  margin-bottom: 12px;
+}
+
+.rp-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.rp-item {
+  margin: 0;
+  padding: 0;
+}
+
+.rp-link {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  text-decoration: none !important;
+  border: none !important;
+  transition: background 0.15s;
+  color: #b4b4bc !important;
+  font-size: 13px;
+}
+
+.rp-link:hover {
+  background: rgba(91, 141, 206, 0.08);
+}
+
+.rp-badge {
+  font-family: 'Space Mono', monospace;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  padding: 2px 5px;
+  border-radius: 3px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.rp-type-pol {
+  background: rgba(91, 141, 206, 0.15);
+  color: #5b8dce;
+}
+
+.rp-type-donor {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+}
+
+.rp-type-story {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+.rp-type-other {
+  background: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
+}
+
+.rp-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #c8c8d0;
+}
+
+.rp-shared {
+  font-family: 'Space Mono', monospace;
+  font-size: 10px;
+  color: #4a4a54;
+  flex-shrink: 0;
+}
+`
+
+export default (() => RelatedProfiles) satisfies QuartzComponentConstructor

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -28,6 +28,7 @@ import InteractiveGraphs from "./InteractiveGraphs"
 import LandingPage from "./LandingPage"
 import ProfileHeader from "./ProfileHeader"
 import ProfileWidget from "./ProfileWidget"
+import RelatedProfiles from "./RelatedProfiles"
 
 export {
   ArticleTitle,
@@ -60,4 +61,5 @@ export {
   LandingPage,
   ProfileHeader,
   ProfileWidget,
+  RelatedProfiles,
 }

--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -338,14 +338,32 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug, data: 
     return new URL(resolveRelative(currentSlug, slug), location.toString())
   }
 
+  function getContentBadge(slug: string): string {
+    const s = slug.toLowerCase()
+    if (s.startsWith("politicians/"))
+      return `<span class="search-badge search-badge-pol">POLITICIAN</span>`
+    if (s.startsWith("donors"))
+      return `<span class="search-badge search-badge-donor">DONOR</span>`
+    if (s.startsWith("stories/"))
+      return `<span class="search-badge search-badge-story">INVESTIGATION</span>`
+    if (s.startsWith("lobbying") || s.startsWith("k-street"))
+      return `<span class="search-badge search-badge-lobby">K STREET</span>`
+    if (s.startsWith("media"))
+      return `<span class="search-badge search-badge-media">MEDIA</span>`
+    if (s.startsWith("think"))
+      return `<span class="search-badge search-badge-think">THINK TANK</span>`
+    return ``
+  }
+
   const resultToHTML = ({ slug, title, content, tags }: Item) => {
     const htmlTags = tags.length > 0 ? `<ul class="tags">${tags.join("")}</ul>` : ``
+    const badge = getContentBadge(slug)
     const itemTile = document.createElement("a")
     itemTile.classList.add("result-card")
     itemTile.id = slug
     itemTile.href = resolveUrl(slug).toString()
     itemTile.innerHTML = `
-      <h3 class="card-title">${title}</h3>
+      <h3 class="card-title">${badge}${title}</h3>
       ${htmlTags}
       <p class="card-description">${content}</p>
     `

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -406,6 +406,26 @@ strong > code, b > code {
   color: #63636e;
 }
 
+// Search result badges
+.search-badge {
+  font-family: 'Space Mono', monospace;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  margin-right: 8px;
+  vertical-align: middle;
+  display: inline-block;
+}
+
+.search-badge-pol { background: rgba(91, 141, 206, 0.2); color: #5b8dce; }
+.search-badge-donor { background: rgba(34, 197, 94, 0.2); color: #22c55e; }
+.search-badge-story { background: rgba(239, 68, 68, 0.2); color: #ef4444; }
+.search-badge-lobby { background: rgba(245, 158, 11, 0.2); color: #f59e0b; }
+.search-badge-media { background: rgba(168, 85, 247, 0.2); color: #a855f7; }
+.search-badge-think { background: rgba(245, 158, 11, 0.2); color: #f59e0b; }
+
 // --- Table of contents ---
 .toc {
   border-left: 1px solid #1e1e28;


### PR DESCRIPTION
## Summary
Four major features addressing discovery and shareability:

### 1. Related Profiles (right sidebar)
- Auto-detects pages sharing 2+ internal links with the current page
- Shows top 8 related profiles with color-coded type badges (POLITICIAN, DONOR, STORY, etc)
- "Goldman Sachs also funds: Cruz, McConnell, Schumer" — the network effect that makes the database feel alive

### 2. Search Content Type Badges
- Search results now show colored category badges based on slug path
- POLITICIAN (blue), DONOR (green), INVESTIGATION (red), K STREET (amber), MEDIA (purple), THINK TANK (amber)
- Makes scanning results instant — know what you're clicking before you click

### 3. OG Images for Social Sharing
- Re-enabled CustomOgImages plugin with dark theme
- Every page now generates a unique social card (1200x630) for Twitter/Facebook/LinkedIn
- Shared links show title, description, tags, and reading time

### 4. "The Biggest Findings" Page
- Curated top 10 most damning contradictions with one-paragraph hooks
- Links to full investigations (Goldman, AIPAC, PhRMA, Lockheed, Cuba, Koch/Soros, etc)
- Added to landing page Start Here section as primary entry point

## Test plan
- [ ] Open a politician profile — Related Profiles section appears below backlinks
- [ ] Search for "Pelosi" — result shows POLITICIAN badge
- [ ] Share a page URL on Twitter/Slack — preview card appears
- [ ] Navigate to "The Biggest Findings" from landing page Start Here

🤖 Generated with [Claude Code](https://claude.com/claude-code)