### PR TITLE
Mobile nav bar + prev/next articles + folder listing upgrade

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -52,7 +52,8 @@
       "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 40 --repo Guerillapropaganda/donor-map-site --merge)",
       "Bash(find /c/Users/third/donor-map-site/.claude/worktrees/elated-borg/quartz/static -name og-image* -o -name icon.png)",
       "Bash(find C:Usersthirddonor-map-site.claudeworktreeselated-borgcontentStoriesPublished -type f -name *.md -o -name *.json)",
-      "Bash(find 'C:\\\\Users\\\\third\\\\donor-map-site\\\\.claude\\\\worktrees\\\\elated-borg\\\\content\\\\Stories\\\\Published\\\\Contradiction Deep Dives' -type f -name *.md)"
+      "Bash(find 'C:\\\\Users\\\\third\\\\donor-map-site\\\\.claude\\\\worktrees\\\\elated-borg\\\\content\\\\Stories\\\\Published\\\\Contradiction Deep Dives' -type f -name *.md)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 41 --repo Guerillapropaganda/donor-map-site --merge)"
     ]
   }
 }

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -5,7 +5,7 @@ import * as Component from "./quartz/components"
 export const sharedPageComponents: SharedLayout = {
   head: Component.Head(),
   header: [],
-  afterBody: [Component.InteractiveGraphs()],
+  afterBody: [Component.InteractiveGraphs(), Component.ArticleNav(), Component.MobileNav()],
   footer: Component.Footer({
     links: {
       "The Donor Map": "https://guerillapropaganda.github.io/donor-map-site/",

--- a/quartz/components/ArticleNav.tsx
+++ b/quartz/components/ArticleNav.tsx
@@ -1,0 +1,136 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+import { resolveRelative, simplifySlug } from "../util/path"
+
+const ArticleNav: QuartzComponent = ({ fileData, allFiles }: QuartzComponentProps) => {
+  const currentSlug = fileData.slug ?? ""
+  const currentSimple = simplifySlug(currentSlug)
+
+  // Find the parent folder of this page
+  const lastSlash = currentSlug.lastIndexOf("/")
+  if (lastSlash < 0) return null // root-level pages don't get prev/next
+  const parentFolder = currentSlug.substring(0, lastSlash + 1).toLowerCase()
+
+  // Get siblings in the same folder, sorted by title
+  const siblings = allFiles
+    .filter((f) => {
+      const slug = (f.slug ?? "").toLowerCase()
+      const fLastSlash = slug.lastIndexOf("/")
+      if (fLastSlash < 0) return false
+      const fParent = slug.substring(0, fLastSlash + 1)
+      return fParent === parentFolder && slug !== "index" && !slug.endsWith("/index")
+    })
+    .sort((a, b) => {
+      const aTitle = (a.frontmatter?.title ?? a.slug ?? "").toLowerCase()
+      const bTitle = (b.frontmatter?.title ?? b.slug ?? "").toLowerCase()
+      return aTitle.localeCompare(bTitle)
+    })
+
+  if (siblings.length <= 1) return null
+
+  const currentIndex = siblings.findIndex(
+    (f) => simplifySlug(f.slug!) === currentSimple,
+  )
+  if (currentIndex < 0) return null
+
+  const prev = currentIndex > 0 ? siblings[currentIndex - 1] : null
+  const next = currentIndex < siblings.length - 1 ? siblings[currentIndex + 1] : null
+
+  if (!prev && !next) return null
+
+  return (
+    <nav class="article-nav">
+      {prev ? (
+        <a href={resolveRelative(fileData.slug!, prev.slug!)} class="article-nav-link article-nav-prev">
+          <span class="article-nav-direction">Previous</span>
+          <span class="article-nav-title">{prev.frontmatter?.title ?? prev.slug}</span>
+        </a>
+      ) : (
+        <div class="article-nav-spacer" />
+      )}
+      {next ? (
+        <a href={resolveRelative(fileData.slug!, next.slug!)} class="article-nav-link article-nav-next">
+          <span class="article-nav-direction">Next</span>
+          <span class="article-nav-title">{next.frontmatter?.title ?? next.slug}</span>
+        </a>
+      ) : (
+        <div class="article-nav-spacer" />
+      )}
+    </nav>
+  )
+}
+
+ArticleNav.css = `
+.article-nav {
+  display: flex;
+  gap: 12px;
+  margin-top: 40px;
+  padding-top: 20px;
+  border-top: 1px solid #1e1e28;
+}
+
+.article-nav-spacer {
+  flex: 1;
+}
+
+.article-nav-link {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+  border-radius: 6px;
+  border: 1px solid #1e1e28;
+  background: #0e0e14;
+  text-decoration: none !important;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.article-nav-link:hover {
+  border-color: rgba(91, 141, 206, 0.3);
+  background: rgba(91, 141, 206, 0.04);
+}
+
+.article-nav-prev {
+  align-items: flex-start;
+}
+
+.article-nav-next {
+  align-items: flex-end;
+  text-align: right;
+}
+
+.article-nav-direction {
+  font-family: 'Space Mono', monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: #5b8dce;
+}
+
+.article-nav-title {
+  font-size: 13px;
+  color: #b4b4bc;
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+@media (max-width: 800px) {
+  .article-nav {
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 24px;
+    padding-bottom: 20px;
+  }
+
+  .article-nav-next {
+    align-items: flex-start;
+    text-align: left;
+  }
+}
+`
+
+export default (() => ArticleNav) satisfies QuartzComponentConstructor

--- a/quartz/components/InteractiveGraphs.tsx
+++ b/quartz/components/InteractiveGraphs.tsx
@@ -762,14 +762,54 @@ function enhanceTables() {
   }
 }
 
+// Add type badges to folder listing items based on their href
+function enhanceListings() {
+  var items = document.querySelectorAll('.section-li .section');
+  for (var i = 0; i < items.length; i++) {
+    var item = items[i];
+    if (item.dataset.badged) continue;
+    item.dataset.badged = 'true';
+    var link = item.querySelector('a');
+    if (!link) continue;
+    var href = (link.getAttribute('href') || '').toLowerCase();
+    var badge = null;
+    if (href.indexOf('/politicians/') !== -1) {
+      badge = 'POL';
+      var cls = 'listing-badge-pol';
+    } else if (href.indexOf('/donors') !== -1) {
+      badge = 'DONOR';
+      var cls = 'listing-badge-donor';
+    } else if (href.indexOf('/stories/') !== -1) {
+      badge = 'STORY';
+      var cls = 'listing-badge-story';
+    } else if (href.indexOf('/lobbying') !== -1 || href.indexOf('/k-street') !== -1) {
+      badge = 'K ST';
+      var cls = 'listing-badge-lobby';
+    } else if (href.indexOf('/media') !== -1) {
+      badge = 'MEDIA';
+      var cls = 'listing-badge-media';
+    } else if (href.indexOf('/think') !== -1) {
+      badge = 'THINK';
+      var cls = 'listing-badge-think';
+    }
+    if (badge) {
+      var span = document.createElement('span');
+      span.className = 'listing-badge ' + cls;
+      span.textContent = badge;
+      item.insertBefore(span, item.firstChild);
+    }
+  }
+}
+
 initInteractive();
 replaceEmDashes();
 cleanFolderTitle();
 cleanListingNames();
 hideDataviewFields();
 enhanceTables();
+enhanceListings();
 document.addEventListener('nav', function() {
-  setTimeout(function() { initInteractive(); replaceEmDashes(); cleanFolderTitle(); cleanListingNames(); hideDataviewFields(); enhanceTables(); }, 100);
+  setTimeout(function() { initInteractive(); replaceEmDashes(); cleanFolderTitle(); cleanListingNames(); hideDataviewFields(); enhanceTables(); enhanceListings(); }, 100);
 });
 `
 

--- a/quartz/components/MobileNav.tsx
+++ b/quartz/components/MobileNav.tsx
@@ -1,0 +1,97 @@
+import { QuartzComponent, QuartzComponentConstructor, QuartzComponentProps } from "./types"
+
+const MobileNav: QuartzComponent = ({ cfg }: QuartzComponentProps) => {
+  const baseUrl = cfg.baseUrl ?? ""
+  const slashIdx = baseUrl.indexOf("/")
+  const basePath = slashIdx >= 0 ? "/" + baseUrl.substring(slashIdx + 1) : ""
+
+  const navItems = [
+    { label: "Home", icon: "H", href: `${basePath}/` },
+    { label: "Politicians", icon: "P", href: `${basePath}/Politicians` },
+    { label: "Donors", icon: "D", href: `${basePath}/Donors--and--Power-Networks` },
+    { label: "Stories", icon: "S", href: `${basePath}/Stories` },
+    { label: "Findings", icon: "F", href: `${basePath}/Stories/Published/The-Biggest-Findings` },
+  ]
+
+  return (
+    <nav class="mobile-bottom-nav">
+      {navItems.map((item) => (
+        <a href={item.href} class="mobile-nav-item">
+          <span class="mobile-nav-icon">{item.icon}</span>
+          <span class="mobile-nav-label">{item.label}</span>
+        </a>
+      ))}
+    </nav>
+  )
+}
+
+MobileNav.css = `
+/* Mobile bottom nav — only visible on phones */
+.mobile-bottom-nav {
+  display: none;
+}
+
+@media (max-width: 800px) {
+  .mobile-bottom-nav {
+    display: flex;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 999;
+    background: rgba(12, 12, 15, 0.95);
+    backdrop-filter: blur(12px);
+    border-top: 1px solid #1e1e28;
+    padding: 6px 0;
+    padding-bottom: calc(6px + env(safe-area-inset-bottom));
+    justify-content: space-around;
+    align-items: center;
+  }
+
+  .mobile-nav-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    text-decoration: none !important;
+    border: none !important;
+    padding: 4px 8px;
+    min-width: 56px;
+    transition: color 0.15s;
+  }
+
+  .mobile-nav-icon {
+    font-family: 'Space Mono', monospace;
+    font-size: 16px;
+    font-weight: 700;
+    color: #5b8dce;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
+    background: rgba(91, 141, 206, 0.1);
+  }
+
+  .mobile-nav-label {
+    font-family: 'Space Mono', monospace;
+    font-size: 9px;
+    letter-spacing: 0.5px;
+    color: #63636e;
+  }
+
+  .mobile-nav-item:hover .mobile-nav-icon,
+  .mobile-nav-item:active .mobile-nav-icon {
+    background: rgba(91, 141, 206, 0.2);
+    color: #8bb5e8;
+  }
+
+  /* Add bottom padding to page content so it doesn't get hidden behind nav */
+  footer {
+    padding-bottom: 70px !important;
+  }
+}
+`
+
+export default (() => MobileNav) satisfies QuartzComponentConstructor

--- a/quartz/components/index.ts
+++ b/quartz/components/index.ts
@@ -29,6 +29,8 @@ import LandingPage from "./LandingPage"
 import ProfileHeader from "./ProfileHeader"
 import ProfileWidget from "./ProfileWidget"
 import RelatedProfiles from "./RelatedProfiles"
+import MobileNav from "./MobileNav"
+import ArticleNav from "./ArticleNav"
 
 export {
   ArticleTitle,
@@ -62,4 +64,6 @@ export {
   ProfileHeader,
   ProfileWidget,
   RelatedProfiles,
+  MobileNav,
+  ArticleNav,
 }

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -551,8 +551,8 @@ footer a {
 ul.section-ul {
   margin-top: 8px !important;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 10px;
 }
 
 .section-li {
@@ -562,15 +562,19 @@ ul.section-ul {
 }
 
 .section-li .section {
-  display: block !important;
+  display: flex !important;
+  align-items: center;
+  gap: 10px;
   background: #111118;
   border: 1px solid #1e1e28;
-  border-radius: 6px;
+  border-left: 3px solid #1e1e28;
+  border-radius: 0 6px 6px 0;
   padding: 12px 16px;
   transition: border-color 0.2s, background 0.2s;
 
   &:hover {
     border-color: rgba(91, 141, 206, 0.35);
+    border-left-color: #5b8dce;
     background: #151520;
   }
 }
@@ -584,10 +588,18 @@ ul.section-ul {
   display: none !important;
 }
 
+.section-li .section .desc {
+  flex: 1;
+  min-width: 0;
+}
+
 .section-li .section .desc h3 {
   font-size: 0.88rem !important;
   line-height: 1.3;
   margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .section-li .section a {
@@ -599,6 +611,25 @@ ul.section-ul {
 .section-li .section a:hover {
   color: #8bb5e8 !important;
 }
+
+// Folder listing type badges (injected by DOM script)
+.listing-badge {
+  font-family: 'Space Mono', monospace;
+  font-size: 7px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  padding: 3px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.listing-badge-pol { background: rgba(91, 141, 206, 0.15); color: #5b8dce; }
+.listing-badge-donor { background: rgba(34, 197, 94, 0.15); color: #22c55e; }
+.listing-badge-story { background: rgba(239, 68, 68, 0.15); color: #ef4444; }
+.listing-badge-lobby { background: rgba(245, 158, 11, 0.15); color: #f59e0b; }
+.listing-badge-media { background: rgba(168, 85, 247, 0.15); color: #a855f7; }
+.listing-badge-think { background: rgba(245, 158, 11, 0.15); color: #f59e0b; }
 
 // --- Horizontal rules ---
 hr {


### PR DESCRIPTION
## Summary
Three navigation improvements targeting mobile and discovery:

### 1. Mobile Bottom Nav Bar
- Fixed bar at bottom of mobile screens with 5 key sections: Home, Politicians, Donors, Stories, Findings
- App-like navigation always visible without opening hamburger menu
- Respects safe-area-inset for notched phones
- Hidden on desktop

### 2. Prev/Next Article Navigation
- Shows previous and next pages (in same folder) at bottom of every article
- Sorted alphabetically by title within folder siblings
- Responsive: side-by-side on desktop, stacked on mobile
- Keeps visitors browsing without backing out to listings

### 3. Folder Listing Upgrade
- Cards get left-border accent on hover (steel blue)
- Type badges injected via DOM script (POL, DONOR, STORY, K ST, MEDIA, THINK)
- Wider grid columns (240px min), text overflow ellipsis
- Better visual hierarchy

## Test plan
- [ ] Mobile: bottom nav bar visible, tapping icons navigates correctly
- [ ] Open any article: prev/next links appear at bottom
- [ ] Open Politicians folder: cards show POL badges, left border on hover
- [ ] Desktop: bottom nav bar hidden, prev/next shows side-by-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)