### PR TITLE
Graph colors, RSS link, footer columns

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -53,7 +53,18 @@
       "Bash(find /c/Users/third/donor-map-site/.claude/worktrees/elated-borg/quartz/static -name og-image* -o -name icon.png)",
       "Bash(find C:Usersthirddonor-map-site.claudeworktreeselated-borgcontentStoriesPublished -type f -name *.md -o -name *.json)",
       "Bash(find 'C:\\\\Users\\\\third\\\\donor-map-site\\\\.claude\\\\worktrees\\\\elated-borg\\\\content\\\\Stories\\\\Published\\\\Contradiction Deep Dives' -type f -name *.md)",
-      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 41 --repo Guerillapropaganda/donor-map-site --merge)"
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 41 --repo Guerillapropaganda/donor-map-site --merge)",
+      "Bash(\"/c/Program Files/GitHub CLI/gh.exe\" pr merge 42 --repo Guerillapropaganda/donor-map-site --merge)",
+      "Bash(cmd.exe /c \"dir /AL C:\\\\Users\\\\third\\\\donor-map-site 2>/dev/null; echo ---; cmd.exe /c fsutil\" reparsepoint query C:Usersthirddonor-map-sitecontent)",
+      "Bash(cmd.exe /c \"fsutil reparsepoint query C:\\\\Users\\\\third\\\\donor-map-site\\\\content\")",
+      "Bash(echo \"EXIT: $?\")",
+      "Bash(while read:*)",
+      "Bash(do echo:*)",
+      "Bash(ls -d \"/c/Users/third/donor-map-site/.claude/worktrees/elated-borg/content\"/*/)",
+      "Bash(__NEW_LINE_04deda78aeee4597__ find:*)",
+      "Bash(__NEW_LINE_4b5cd4e9c9d2a824__ grep:*)",
+      "Bash(__NEW_LINE_cd965d168c0aa7e6__ grep:*)",
+      "Bash(__NEW_LINE_f8f217d27ccdff8e__ grep:*)"
     ]
   }
 }

--- a/quartz/components/Footer.tsx
+++ b/quartz/components/Footer.tsx
@@ -7,17 +7,33 @@ interface Options {
   links: Record<string, string>
 }
 
-const siteNavLinks = [
-  { text: "Politicians", slug: "Politicians" },
-  { text: "Donors & Power Networks", slug: "Donors--and--Power-Networks" },
-  { text: "Investigations", slug: "Stories" },
-  { text: "Lobbyists & K Street", slug: "Lobbying-Firms--and--K-Street" },
-  { text: "Media Pipeline", slug: "Media-Pipeline" },
-  { text: "Think Tanks", slug: "Think-Tanks" },
-  { text: "Guided Tour", slug: "Stories/Follow-the-Money---Guided-Tour" },
-  { text: "Browse by Pattern", slug: "Stories/Browse-by-Pattern" },
-  { text: "About", slug: "About-the-Donor-Map" },
-  { text: "Methodology", slug: "Methodology" },
+const footerColumns = [
+  {
+    label: "EXPLORE",
+    links: [
+      { text: "Politicians", slug: "Politicians" },
+      { text: "Donors & Power Networks", slug: "Donors--and--Power-Networks" },
+      { text: "Lobbyists & K Street", slug: "Lobbying-Firms--and--K-Street" },
+      { text: "Media Pipeline", slug: "Media-Pipeline" },
+      { text: "Think Tanks", slug: "Think-Tanks" },
+    ],
+  },
+  {
+    label: "INVESTIGATIONS",
+    links: [
+      { text: "Biggest Findings", slug: "Stories/Published/The-Biggest-Findings" },
+      { text: "Guided Tour", slug: "Stories/Follow-the-Money---Guided-Tour" },
+      { text: "Browse by Pattern", slug: "Stories/Browse-by-Pattern" },
+      { text: "All Stories", slug: "Stories" },
+    ],
+  },
+  {
+    label: "ABOUT",
+    links: [
+      { text: "About The Donor Map", slug: "About-the-Donor-Map" },
+      { text: "Methodology", slug: "Methodology" },
+    ],
+  },
 ]
 
 export default ((opts?: Options) => {
@@ -30,22 +46,43 @@ export default ((opts?: Options) => {
 
     return (
       <footer class={`${displayClass ?? ""}`}>
-        <nav class="footer-site-nav">
-          {siteNavLinks.map((link) => (
-            <a href={`${basePath}/${link.slug}`}>{link.text}</a>
+        <div class="footer-columns">
+          {footerColumns.map((col) => (
+            <div class="footer-col">
+              <div class="footer-col-label">{col.label}</div>
+              <ul class="footer-col-links">
+                {col.links.map((link) => (
+                  <li>
+                    <a href={`${basePath}/${link.slug}`}>{link.text}</a>
+                  </li>
+                ))}
+              </ul>
+            </div>
           ))}
-        </nav>
-        <p>
-          {i18n(cfg.locale).components.footer.createdWith}{" "}
-          <a href="https://quartz.jzhao.xyz/">Quartz v{version}</a> © {year}
-        </p>
-        <ul>
-          {Object.entries(links).map(([text, link]) => (
-            <li>
-              <a href={link}>{text}</a>
-            </li>
-          ))}
-        </ul>
+          <div class="footer-col">
+            <div class="footer-col-label">SUBSCRIBE</div>
+            <ul class="footer-col-links">
+              <li>
+                <a href={`${basePath}/index.xml`} class="footer-rss-link">
+                  RSS Feed
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div class="footer-bottom">
+          <p>
+            {i18n(cfg.locale).components.footer.createdWith}{" "}
+            <a href="https://quartz.jzhao.xyz/">Quartz v{version}</a> © {year}
+          </p>
+          <ul>
+            {Object.entries(links).map(([text, link]) => (
+              <li>
+                <a href={link}>{text}</a>
+              </li>
+            ))}
+          </ul>
+        </div>
       </footer>
     )
   }

--- a/quartz/components/scripts/graph.inline.ts
+++ b/quartz/components/scripts/graph.inline.ts
@@ -193,15 +193,26 @@ async function renderGraph(graph: HTMLElement, fullSlug: FullSlug) {
     {} as Record<(typeof cssVars)[number], string>,
   )
 
-  // calculate color
+  // calculate color — type-based coloring
+  const nodeTypeColor = (id: string): string | null => {
+    const lower = id.toLowerCase()
+    if (lower.startsWith("politicians/")) return "#5b8dce" // steel blue
+    if (lower.startsWith("donors")) return "#22c55e" // green
+    if (lower.startsWith("stories/")) return "#ef4444" // red
+    if (lower.startsWith("lobbying") || lower.startsWith("k-street")) return "#f59e0b" // amber
+    if (lower.startsWith("media")) return "#a855f7" // purple
+    if (lower.startsWith("think")) return "#f59e0b" // amber
+    return null
+  }
+
   const color = (d: NodeData) => {
     const isCurrent = d.id === slug
     if (isCurrent) {
       return computedStyleMap["--secondary"]
-    } else if (visited.has(d.id) || d.id.startsWith("tags/")) {
+    } else if (d.id.startsWith("tags/")) {
       return computedStyleMap["--tertiary"]
     } else {
-      return computedStyleMap["--gray"]
+      return nodeTypeColor(d.id) ?? computedStyleMap["--gray"]
     }
   }
 

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -503,39 +503,76 @@ footer {
   font-size: 11px;
 }
 
-.footer-site-nav {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px 16px;
-  padding: 16px 0;
-  margin-bottom: 12px;
+.footer-columns {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 24px;
+  padding: 24px 0 20px 0;
   border-bottom: 1px solid #1e1e28;
+  margin-bottom: 12px;
+}
+
+.footer-col-label {
+  font-family: 'Space Mono', monospace;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 2px;
+  color: #63636e;
+  margin-bottom: 10px;
+}
+
+.footer-col-links {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  li { margin: 0; padding: 0; }
 
   a {
     color: #5b8dce !important;
     font-size: 12px;
     font-weight: 500;
     text-decoration: none !important;
-    white-space: nowrap;
     transition: color 0.15s;
 
-    &:hover {
-      color: #8bb5e8 !important;
-    }
+    &:hover { color: #8bb5e8 !important; }
   }
 }
 
-footer > p:first-of-type {
+.footer-rss-link::before {
+  content: "◉ ";
+  color: #f59e0b;
+  font-size: 10px;
+}
+
+.footer-bottom {
   opacity: 0.4;
   font-size: 10px;
+
+  ul {
+    display: flex;
+    gap: 1rem;
+    list-style: none;
+    padding: 0;
+  }
 }
 
 footer a {
   color: #63636e !important;
 }
 
-.footer-site-nav a {
+.footer-col-links a {
   color: #5b8dce !important;
+}
+
+@media (max-width: 800px) {
+  .footer-columns {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px 16px;
+  }
 }
 
 // --- Folder listing pages ---


### PR DESCRIPTION
## Summary
Three visual/navigation improvements:

### Graph Node Color Coding
- Politicians: steel blue (#5b8dce)
- Donors: green (#22c55e)
- Stories: red (#ef4444)
- K Street / Think Tanks: amber (#f59e0b)
- Media: purple (#a855f7)
- Current page: highlighted as secondary color
- Tags: tertiary color

### RSS Subscribe Link
- Added to footer under new "SUBSCRIBE" column
- Amber dot indicator for visibility
- Points to /index.xml (RSS already enabled)

### Footer Column Redesign
- Flat row of links replaced with 4-column grid: Explore, Investigations, About, Subscribe
- Monospace category headers
- 2 columns on mobile

## Test plan
- [ ] Graph shows colored nodes — blue for politicians, green for donors
- [ ] Footer shows 4 organized columns
- [ ] RSS link works and returns XML feed
- [ ] Mobile: footer collapses to 2 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)